### PR TITLE
feat: verify CLI end-to-end, fix EOL model default, expand test coverage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,7 +25,7 @@ OLLAMA_BASE_URL=http://localhost:11434
 LLM_PROVIDER=anthropic
 
 # Model name (provider-specific)
-LLM_MODEL=claude-sonnet-4-20250514
+LLM_MODEL=claude-sonnet-5
 
 # ═══════════════════════════════════════════
 # Messaging (Week 3-4, leave empty for now)

--- a/src/brain/providers/anthropic.js
+++ b/src/brain/providers/anthropic.js
@@ -9,7 +9,7 @@ export class AnthropicProvider {
         this.client = new Anthropic({
             apiKey: config.apiKey || process.env.ANTHROPIC_API_KEY,
         });
-        this.model = config.model || process.env.LLM_MODEL || 'claude-sonnet-4-20250514';
+        this.model = config.model || process.env.LLM_MODEL || 'claude-sonnet-5';
         this.maxTokens = config.maxTokens || 500;
     }
 

--- a/src/config/loader.js
+++ b/src/config/loader.js
@@ -7,13 +7,13 @@ import { readFileSync, existsSync } from 'fs';
 import { parse as parseYaml } from 'yaml';
 import dotenv from 'dotenv';
 
-// Load .env file
-dotenv.config();
+// Load .env file (quiet: suppress dotenv's promotional stdout tips)
+dotenv.config({ quiet: true });
 
 const DEFAULT_CONFIG = {
     llm: {
         provider: 'anthropic',
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-5',
         maxTokens: 500,
     },
     clone: {

--- a/tests/unit/config/loader.test.js
+++ b/tests/unit/config/loader.test.js
@@ -1,0 +1,67 @@
+/**
+ * loadConfig — defaults, YAML file override, env override, deep merge
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { loadConfig } from '../../../src/config/loader.js';
+
+let dir;
+const savedEnv = {};
+const ENV_KEYS = ['LLM_PROVIDER', 'LLM_MODEL', 'DATA_DIR'];
+
+beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'openself-cfg-'));
+    for (const k of ENV_KEYS) savedEnv[k] = process.env[k];
+    for (const k of ENV_KEYS) delete process.env[k];
+});
+afterEach(() => {
+    for (const k of ENV_KEYS) {
+        if (savedEnv[k] === undefined) delete process.env[k];
+        else process.env[k] = savedEnv[k];
+    }
+    rmSync(dir, { recursive: true, force: true });
+});
+
+describe('loadConfig defaults', () => {
+    it('returns built-in defaults when no config file is found', () => {
+        const cfg = loadConfig(join(dir, 'missing.yml'));
+        expect(cfg.llm.provider).toBe('anthropic');
+        expect(cfg.llm.maxTokens).toBe(500);
+        expect(cfg.safety.safeMode).toBe(true);
+    });
+});
+
+describe('loadConfig file override', () => {
+    it('merges a YAML file over defaults (deep merge keeps untouched keys)', () => {
+        const p = join(dir, 'openself.yml');
+        writeFileSync(p, 'llm:\n  provider: openai\n  maxTokens: 999\n', 'utf-8');
+        const cfg = loadConfig(p);
+        expect(cfg.llm.provider).toBe('openai');
+        expect(cfg.llm.maxTokens).toBe(999);
+        // untouched default still present
+        expect(cfg.safety.safeMode).toBe(true);
+    });
+
+    it('falls back to defaults when the YAML is invalid', () => {
+        const p = join(dir, 'bad.yml');
+        writeFileSync(p, 'llm: [::: not valid', 'utf-8');
+        const cfg = loadConfig(p);
+        expect(cfg.llm.provider).toBe('anthropic');
+    });
+});
+
+describe('loadConfig env override', () => {
+    it('env vars take precedence over file and defaults', () => {
+        const p = join(dir, 'openself.yml');
+        writeFileSync(p, 'llm:\n  provider: openai\n', 'utf-8');
+        process.env.LLM_PROVIDER = 'deepseek';
+        process.env.LLM_MODEL = 'custom-model';
+        process.env.DATA_DIR = '/tmp/custom-data';
+        const cfg = loadConfig(p);
+        expect(cfg.llm.provider).toBe('deepseek');
+        expect(cfg.llm.model).toBe('custom-model');
+        expect(cfg.data.dir).toBe('/tmp/custom-data');
+    });
+});

--- a/tests/unit/ghost/ghost.test.js
+++ b/tests/unit/ghost/ghost.test.js
@@ -1,0 +1,89 @@
+/**
+ * GhostMode — heartbeat presence, enable/disable, status, reply gating
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { GhostMode } from '../../../src/ghost/ghost.js';
+
+let dir;
+beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'openself-ghost-'));
+});
+afterEach(() => {
+    vi.useRealTimers();
+    rmSync(dir, { recursive: true, force: true });
+});
+
+describe('GhostMode presence', () => {
+    it('reports offline when no heartbeat file exists', () => {
+        const g = new GhostMode(dir);
+        expect(g.isUserOffline()).toBe(true);
+        expect(g.getStatus().status).toBe('unknown');
+    });
+
+    it('ping marks the user online and recent', () => {
+        const g = new GhostMode(dir);
+        g.ping();
+        expect(g.isUserOffline()).toBe(false);
+    });
+
+    it('treats a stale heartbeat (> 5 min) as offline', () => {
+        vi.useFakeTimers();
+        const g = new GhostMode(dir);
+        g.ping();
+        vi.advanceTimersByTime(6 * 60 * 1000);
+        expect(g.isUserOffline()).toBe(true);
+    });
+});
+
+describe('GhostMode enable/disable/status', () => {
+    it('enable sets ghost status and marks user not-online', () => {
+        const g = new GhostMode(dir);
+        g.enable();
+        const s = g.getStatus();
+        expect(s.ghostMode).toBe(true);
+        expect(s.status).toBe('ghost');
+    });
+
+    it('disable clears ghost mode and marks online', () => {
+        const g = new GhostMode(dir);
+        g.enable();
+        g.disable();
+        const s = g.getStatus();
+        expect(s.ghostMode).toBe(false);
+        expect(s.status).toBe('online');
+    });
+
+    it('shouldCloneReply is true only in ghost mode with an offline user', () => {
+        vi.useFakeTimers();
+        const g = new GhostMode(dir);
+        g.enable(); // ghost on, timestamp now
+        vi.advanceTimersByTime(6 * 60 * 1000); // user goes stale/offline
+        expect(g.shouldCloneReply()).toBe(true);
+
+        g.disable();
+        expect(g.shouldCloneReply()).toBe(false);
+    });
+});
+
+describe('GhostMode heartbeat loop', () => {
+    it('startHeartbeat pings immediately then on interval; stopHeartbeat clears it', () => {
+        vi.useFakeTimers();
+        const g = new GhostMode(dir);
+        const pingSpy = vi.spyOn(g, 'ping');
+        g.startHeartbeat(1000);
+        expect(pingSpy).toHaveBeenCalledTimes(1); // immediate
+        vi.advanceTimersByTime(3000);
+        expect(pingSpy).toHaveBeenCalledTimes(4); // + 3 intervals
+        g.stopHeartbeat();
+        vi.advanceTimersByTime(3000);
+        expect(pingSpy).toHaveBeenCalledTimes(4); // no more after stop
+    });
+
+    it('stopHeartbeat is safe to call when no loop is running', () => {
+        const g = new GhostMode(dir);
+        expect(() => g.stopHeartbeat()).not.toThrow();
+    });
+});

--- a/tests/unit/memory/conversation.test.js
+++ b/tests/unit/memory/conversation.test.js
@@ -1,0 +1,87 @@
+/**
+ * ConversationMemory — per-contact session window, context formatting, persistence
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { ConversationMemory } from '../../../src/memory/conversation.js';
+
+let dir;
+beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'openself-conv-'));
+});
+afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+});
+
+describe('ConversationMemory.addExchange + getRecentContext', () => {
+    it('returns empty string for an unknown contact', () => {
+        const mem = new ConversationMemory(dir);
+        expect(mem.getRecentContext('Nobody')).toBe('');
+    });
+
+    it('formats stored exchanges as "contact / You" pairs', () => {
+        const mem = new ConversationMemory(dir);
+        mem.addExchange('Alice', 'hi', 'ê');
+        const ctx = mem.getRecentContext('Alice');
+        expect(ctx).toContain('Alice: hi');
+        expect(ctx).toContain('You: ê');
+    });
+
+    it('caps returned exchanges at maxExchanges', () => {
+        const mem = new ConversationMemory(dir);
+        for (let i = 0; i < 5; i++) mem.addExchange('Bob', `m${i}`, `r${i}`);
+        const ctx = mem.getRecentContext('Bob', 2);
+        expect(ctx).toContain('m3');
+        expect(ctx).toContain('m4');
+        expect(ctx).not.toContain('m0');
+    });
+
+    it('keeps only the last 20 exchanges in the session window', () => {
+        const mem = new ConversationMemory(dir);
+        for (let i = 0; i < 25; i++) mem.addExchange('Carol', `m${i}`, `r${i}`);
+        const ctx = mem.getRecentContext('Carol', 100);
+        expect(ctx).not.toContain('m4'); // dropped
+        expect(ctx).toContain('m24'); // kept
+    });
+});
+
+describe('ConversationMemory.getActiveContacts + clearSession', () => {
+    it('lists contacts with message counts, most recent first', () => {
+        const mem = new ConversationMemory(dir);
+        mem.addExchange('A', 'x', 'y');
+        mem.addExchange('A', 'x2', 'y2');
+        mem.addExchange('B', 'z', 'w');
+        const contacts = mem.getActiveContacts();
+        expect(contacts.map((c) => c.name).sort()).toEqual(['A', 'B']);
+        expect(contacts.find((c) => c.name === 'A').messageCount).toBe(2);
+    });
+
+    it('clearSession drops a contact from active list', () => {
+        const mem = new ConversationMemory(dir);
+        mem.addExchange('A', 'x', 'y');
+        mem.clearSession('A');
+        expect(mem.getActiveContacts()).toHaveLength(0);
+        expect(mem.getRecentContext('A')).toBe('');
+    });
+});
+
+describe('ConversationMemory persistence', () => {
+    it('appends exchanges to memory.md and summarizes them', () => {
+        const mem = new ConversationMemory(dir);
+        mem.addExchange('A', 'hi there', 'oke');
+        mem.addExchange('A', 'again', 'ừ');
+        expect(existsSync(join(dir, 'memory.md'))).toBe(true);
+        expect(readFileSync(join(dir, 'memory.md'), 'utf-8')).toContain('hi there');
+
+        const summary = mem.getMemorySummary();
+        expect(summary.totalExchanges).toBe(2);
+        expect(summary.sizeBytes).toBeGreaterThan(0);
+    });
+
+    it('getMemorySummary returns null when no memory file exists', () => {
+        const mem = new ConversationMemory(dir);
+        expect(mem.getMemorySummary()).toBeNull();
+    });
+});

--- a/tests/unit/personality/soul-generator.test.js
+++ b/tests/unit/personality/soul-generator.test.js
@@ -1,0 +1,121 @@
+/**
+ * generateSoulMd / saveSoulMd — section rendering across languages, emoji tiers,
+ * relationships and reply-time formatting.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { generateSoulMd, saveSoulMd } from '../../../src/personality/soul-generator.js';
+
+function basePersonality(overrides = {}) {
+    return {
+        primaryLanguage: 'English',
+        totalMessages: 100,
+        avgMessageLength: 42,
+        avgWordCount: 8,
+        emojiFrequency: 0.05,
+        formality: 'casual',
+        humorPatterns: ['sarcasm'],
+        greetingStyle: 'hey',
+        responseTimeAvg: 45000,
+        topEmojis: [{ emoji: '😂' }, { emoji: '🔥' }],
+        catchphrases: ['lol', 'fr'],
+        topWords: [{ word: 'yeah' }, { word: 'nice' }],
+        pronounUsage: [],
+        toneDiacritics: false,
+        abbreviations: [],
+        usesSlang: false,
+        ...overrides,
+    };
+}
+
+let dir;
+beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'openself-soulgen-'));
+});
+afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+});
+
+describe('generateSoulMd', () => {
+    it('renders identity, catchphrases and top emojis for an English profile', () => {
+        const md = generateSoulMd(
+            basePersonality(),
+            { capitalizationStyle: 'lowercase' },
+            {
+                name: 'Zed',
+            },
+        );
+        expect(md).toContain('- Name: Zed');
+        expect(md).toContain('Language: English');
+        expect(md).toContain('lol');
+        expect(md).toContain('😂');
+        expect(md).toContain('Capitalization: lowercase');
+    });
+
+    it('classifies emoji frequency into High / Medium / Low tiers', () => {
+        const high = generateSoulMd(basePersonality({ emojiFrequency: 0.5 }), {}, {});
+        const med = generateSoulMd(basePersonality({ emojiFrequency: 0.2 }), {}, {});
+        const low = generateSoulMd(basePersonality({ emojiFrequency: 0.05 }), {}, {});
+        expect(high).toContain('Emoji frequency: High');
+        expect(med).toContain('Emoji frequency: Medium');
+        expect(low).toContain('Emoji frequency: Low');
+    });
+
+    it('adds a Vietnamese Style section with pronouns, abbreviations and slang', () => {
+        const md = generateSoulMd(
+            basePersonality({
+                primaryLanguage: 'Vietnamese',
+                pronounUsage: ['t', 'm'],
+                toneDiacritics: true,
+                abbreviations: ['ko', 'dc'],
+                usesSlang: true,
+            }),
+            { capitalizationStyle: 'lowercase' },
+            {},
+        );
+        expect(md).toContain('## Vietnamese Style');
+        expect(md).toContain('Pronoun usage: t, m');
+        expect(md).toContain('Abbreviations: ko, dc');
+        expect(md).toContain('Slang: Frequently used');
+        expect(md).toContain('để t hỏi lại');
+    });
+
+    it('renders a Relationships section when contacts are provided', () => {
+        const md = generateSoulMd(
+            basePersonality(),
+            {},
+            {
+                name: 'Zed',
+                contacts: { Alice: { relationship: 'bestie', messageCount: 12 } },
+            },
+        );
+        expect(md).toContain('## Relationships');
+        expect(md).toContain('@Alice: bestie (12 messages)');
+    });
+
+    it('formats reply time across second / minute / hour / instant buckets', () => {
+        expect(generateSoulMd(basePersonality({ responseTimeAvg: 30000 }), {}, {})).toContain(
+            '30s',
+        );
+        expect(generateSoulMd(basePersonality({ responseTimeAvg: 120000 }), {}, {})).toContain(
+            '2min',
+        );
+        expect(generateSoulMd(basePersonality({ responseTimeAvg: 7200000 }), {}, {})).toContain(
+            '2h',
+        );
+        expect(generateSoulMd(basePersonality({ responseTimeAvg: -1 }), {}, {})).toContain(
+            'instant',
+        );
+    });
+});
+
+describe('saveSoulMd', () => {
+    it('writes SOUL.md to the data dir and returns its path', () => {
+        const path = saveSoulMd('# SOUL\ncontent', dir);
+        expect(path).toBe(join(dir, 'SOUL.md'));
+        expect(existsSync(path)).toBe(true);
+        expect(readFileSync(path, 'utf-8')).toContain('content');
+    });
+});

--- a/tests/unit/safety/review-queue.test.js
+++ b/tests/unit/safety/review-queue.test.js
@@ -1,0 +1,71 @@
+/**
+ * ReviewQueue — enqueue, pending filter, approve/reject transitions, persistence
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { ReviewQueue } from '../../../src/safety/review-queue.js';
+
+let dir;
+beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'openself-rq-'));
+});
+afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+});
+
+describe('ReviewQueue add + getPending', () => {
+    it('adds items with a generated id, timestamp and pending status', () => {
+        const q = new ReviewQueue(dir);
+        q.add({ contact: 'A', message: 'm', reply: 'r' });
+        const pending = q.getPending();
+        expect(pending).toHaveLength(1);
+        expect(pending[0].status).toBe('pending');
+        expect(pending[0].id).toBeTruthy();
+        expect(pending[0].contact).toBe('A');
+    });
+
+    it('persists across instances (loads from disk)', () => {
+        const q1 = new ReviewQueue(dir);
+        q1.add({ contact: 'A', message: 'm', reply: 'r' });
+        const q2 = new ReviewQueue(dir);
+        expect(q2.getPending()).toHaveLength(1);
+    });
+});
+
+describe('ReviewQueue approve/reject/stats', () => {
+    it('approve moves an item out of pending', () => {
+        const q = new ReviewQueue(dir);
+        q.add({ contact: 'A', message: 'm', reply: 'r' });
+        const id = q.getPending()[0].id;
+        const item = q.approve(id);
+        expect(item.status).toBe('approved');
+        expect(q.getPending()).toHaveLength(0);
+        expect(q.getStats()).toMatchObject({ pending: 0, approved: 1, total: 1 });
+    });
+
+    it('reject records the edited reply and marks rejected', () => {
+        const q = new ReviewQueue(dir);
+        q.add({ contact: 'A', message: 'm', reply: 'r' });
+        const id = q.getPending()[0].id;
+        const item = q.reject(id, 'better reply');
+        expect(item.status).toBe('rejected');
+        expect(item.editedReply).toBe('better reply');
+        expect(q.getStats()).toMatchObject({ rejected: 1 });
+    });
+
+    it('approve/reject on an unknown id returns undefined and does not throw', () => {
+        const q = new ReviewQueue(dir);
+        expect(q.approve('nope')).toBeUndefined();
+        expect(q.reject('nope', 'x')).toBeUndefined();
+    });
+});
+
+describe('ReviewQueue corrupted store', () => {
+    it('starts empty when the queue file is corrupted JSON', () => {
+        writeFileSync(join(dir, 'review-queue.json'), '{ not json', 'utf-8');
+        const q = new ReviewQueue(dir);
+        expect(q.getPending()).toEqual([]);
+    });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -32,24 +32,16 @@ export default defineConfig({
                 'src/gateway/telegram.js',
                 'src/gateway/discord.js',
                 'src/gateway/router.js',
-                // Arena, ghost, conversation memory — phase-05+ coverage
+                // Arena orchestrator — LLM-driven debate loop, exercised via CLI
                 'src/arena/arena.js',
-                'src/ghost/ghost.js',
-                'src/memory/conversation.js',
-                // Soul generator — phase-05+ coverage
-                'src/personality/soul-generator.js',
-                // Review queue — requires FS, low priority
-                'src/safety/review-queue.js',
-                // Config loader — requires YAML file on disk
-                'src/config/loader.js',
-                // Web server — requires supertest (not installed); security logic tested inline
+                // Web server — HTTP integration needs supertest; boot smoke-tested separately
                 'src/web/server.js',
                 'src/**/*.test.js',
             ],
             thresholds: {
-                lines: 60,
-                functions: 70,
-                branches: 70,
+                lines: 80,
+                functions: 85,
+                branches: 72,
             },
         },
     },


### PR DESCRIPTION
## Product correctness

Ran every CLI command that doesn't need credentials end-to-end (CI previously smoke-tested only `feed` + `--help`):

- ✅ `feed`, `ghost` (status/on/off), `review`, `profile export`, `share --web` (express 5 server boots, `/api/info` returns JSON, `/` → 200)
- ✅ `test` runs the scoring flow (fails only on a missing API key)

**Bugs found and fixed:**
- 🔴 The default Anthropic model `claude-sonnet-4-20250514` reached end-of-life, so a fresh clone using defaults failed even with a valid key. Updated to `claude-sonnet-5` across the provider, config loader, and `.env.example`.
- 🟡 dotenv 17 leaked a promotional banner into every command's stdout → `dotenv.config({ quiet: true })`.

## Coverage expansion

Added unit tests for five modules that were excluded from coverage:

| Module | What's covered |
|---|---|
| `ConversationMemory` | session window (20-cap), context formatting, memory.md persistence, summary |
| `GhostMode` | heartbeat freshness, enable/disable, status tiers, reply gating, interval loop |
| `ReviewQueue` | enqueue, pending filter, approve/reject, stats, corrupted-store recovery |
| `loadConfig` | defaults, YAML file override, env precedence, invalid-YAML fallback |
| `generateSoulMd` / `saveSoulMd` | language sections, emoji tiers, relationships, reply-time buckets |

Removed those five from the coverage exclude list and **raised thresholds** from lines 60 / funcs 70 / branches 70 → **lines 80 / funcs 85 / branches 72**. Only the LLM-driven arena loop and the HTTP web server remain excluded (documented). Suite grew 292 → **324 tests**.

## Verification

Local CI parity all green: lint, format:check, test (324/324), coverage (thresholds met with no `data/` dir, matching CI), CLI feed smoke, publint, `npm audit` (0 vulns).