### PR TITLE
chore(release): prep 0.7.0 — badges, release workflow, publish-readiness

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+# Publishes to npm when a version tag (e.g. v0.7.0) is pushed. Requires an
+# NPM_TOKEN repository secret. prepublishOnly (lint + test + publint) gates the
+# publish, and npm provenance is attached via the id-token permission.
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: 'https://registry.npmjs.org'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [0.7.0] — 2026-07-07
+
+### Changed (BREAKING)
+- **Requires Node.js ≥ 20.** Node 18 dropped from support and the CI matrix — `@whiskeysockets/baileys` hard-fails its install engine check on Node < 20, so the previous `>=18` claim never actually installed.
+- **Default LLM model** updated from the end-of-life `claude-sonnet-4-20250514` to `claude-sonnet-5` (provider, config loader, `.env.example`). Fresh clones on defaults previously failed even with a valid key.
+
+### Fixed
+- **CI was never green.** `package-lock.json` was git-ignored so `npm ci` failed at install on every runner; two integration tests failed from a mock-teardown bug; 81 files were unformatted behind a non-blocking format step. Lockfile committed, tests stabilized, formatting enforced with LF normalization.
+- **RAG retrieval silently returned nothing** after the vectra 0.15 upgrade — `queryItems` gained a `query` argument, shifting `topK` out of position. Fixed and guarded with a non-empty-result test.
+- **dotenv** no longer prints its promotional banner into every command (`{ quiet: true }`).
+
+### Security
+- `npm audit`: **14 vulnerabilities (2 critical, 5 high) → 0.** Every dependency bumped to latest; the last undici advisories cleared via a scoped `overrides` pin instead of downgrading discord.js.
+
+### Added
+- All dependencies upgraded to current majors: ESLint 10, Vitest 4, zod 4, express 5, openai 6, `@anthropic-ai/sdk` 0.110, commander 15, inquirer 14, vectra 0.15; baileys pinned to latest stable 6.7.x.
+- **Dependabot** (weekly, grouped) + a non-blocking `npm audit` CI step.
+- Test suite grown to **324 tests**; coverage thresholds raised to lines 80 / functions 85 / branches 72, with previously-excluded core modules (ConversationMemory, GhostMode, ReviewQueue, loadConfig, generateSoulMd) now covered.
+- End-to-end verification pass over all credential-free CLI commands.
+
 ## [0.6.0] — 2026-05-07
 
 ### Fixed (P0)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # 🧑 OpenSelf
 
-[![npm version](https://img.shields.io/badge/npm-v0.6.0-blue)](https://www.npmjs.com/package/openself)
+[![npm version](https://img.shields.io/npm/v/openself?color=blue)](https://www.npmjs.com/package/openself)
+[![npm downloads](https://img.shields.io/npm/dm/openself)](https://www.npmjs.com/package/openself)
+[![CI](https://github.com/Open-Self/Open-Self/actions/workflows/ci.yml/badge.svg)](https://github.com/Open-Self/Open-Self/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](./LICENSE)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D20-brightgreen)](https://nodejs.org)
-[![CI](https://github.com/Open-Self/open-self/actions/workflows/ci.yml/badge.svg)](https://github.com/Open-Self/open-self/actions)
-[![Tests](https://img.shields.io/badge/tests-vitest-purple)](./docs/code-standards.md)
 
 ### Your AI clone. Your messages. Your machine.
 
@@ -29,7 +29,7 @@ OpenSelf learns from YOUR real messages — your vocabulary, humor, emoji habits
 
 ```bash
 # Install
-git clone https://github.com/Open-Self/open-self.git
+git clone https://github.com/Open-Self/Open-Self.git
 cd open-self && npm install
 
 # Feed your personality
@@ -130,7 +130,7 @@ npx openself ghost       # Check status
 See the full [Setup Guide](./docs/setup-guide.md) for detailed instructions.
 
 ```bash
-git clone https://github.com/Open-Self/open-self.git
+git clone https://github.com/Open-Self/Open-Self.git
 cd open-self && npm install
 cp .env.example .env    # Edit with your API key
 ```
@@ -239,7 +239,7 @@ See [Safety Guide](./docs/safety-guide.md) for safety features and [System Archi
 PRs welcome! See [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines.
 
 ```bash
-git clone https://github.com/Open-Self/open-self.git
+git clone https://github.com/Open-Self/Open-Self.git
 cd open-self && npm install
 npx openself feed --whatsapp ./test-data/sample-whatsapp.txt --name "Harvey"
 npm test

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openself",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Your AI clone. Your messages. Your machine. Open-source AI personality clone that lives in your messaging apps.",
   "type": "module",
   "sideEffects": false,
@@ -51,11 +51,11 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Open-Self/open-self.git"
+    "url": "git+https://github.com/Open-Self/Open-Self.git"
   },
-  "homepage": "https://github.com/Open-Self/open-self#readme",
+  "homepage": "https://github.com/Open-Self/Open-Self#readme",
   "bugs": {
-    "url": "https://github.com/Open-Self/open-self/issues"
+    "url": "https://github.com/Open-Self/Open-Self/issues"
   },
   "files": [
     "src/",


### PR DESCRIPTION
## What

Prepares OpenSelf for its first real npm publish and makes the README's signals honest.

- **Publish-readiness verified**: `npm pack` → clean install into a temp dir → `npx openself --help` runs from the installed tarball (60 files, 80 kB).
- **Honest badges**: the npm badge was a hardcoded `v0.6.0` even though nothing is published. Replaced with live shields.io npm version + downloads badges; fixed the CI badge and repository URLs to the canonical `Open-Self/Open-Self` casing.
- **Release automation**: `.github/workflows/release.yml` publishes to npm with provenance on a `v*` tag, gated by `prepublishOnly` (lint + test + publint).
- **0.7.0**: version bump + CHANGELOG entry covering the Node 20+ requirement, model-default fix, security (14 → 0), dependency upgrades and coverage growth.

## Not done here (needs you)

The package is **not yet on npm** (`npm view openself` → 404). Publishing needs your npm auth. Until published, the npm badges will read "not found" — that's expected and resolves on first publish.

**To publish**, either:
- add an `NPM_TOKEN` secret and push a `v0.7.0` tag (the release workflow handles the rest), or
- run `npm login` locally and I'll run `npm publish`.

## Verification

lint, format:check, test (324/324), `npm pack` all green on this branch.