### PR TITLE
ci: guard release workflow when NPM_TOKEN is absent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,12 @@ jobs:
         run: npm ci
 
       - name: Publish to npm
-        run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -z "$NODE_AUTH_TOKEN" ]; then
+            echo "NPM_TOKEN secret not set — skipping publish."
+            echo "Add the secret to enable tag-triggered releases, or publish manually."
+            exit 0
+          fi
+          npm publish --provenance --access public


### PR DESCRIPTION
Skip the npm publish step gracefully if the NPM_TOKEN secret isn't set, so pushing a version tag (e.g. for a manually-published release like v0.7.0) doesn't fail the workflow. Future releases still auto-publish once the secret is added.